### PR TITLE
QA: GoalRow 제약 수정

### DIFF
--- a/feature/goal/src/main/kotlin/com/chipichipi/dobedobe/feature/goal/component/GoalRow.kt
+++ b/feature/goal/src/main/kotlin/com/chipichipi/dobedobe/feature/goal/component/GoalRow.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.chipichipi.dobedobe.core.designsystem.component.DobeDobeCheckBox
@@ -58,6 +59,8 @@ fun GoalRow(
             Text(
                 modifier = Modifier.weight(1f),
                 text = goal.title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 style = DobeDobeTheme.typography.heading2,
                 color = DobeDobeTheme.colors.gray800,
             )


### PR DESCRIPTION
GoalRow 제약을 잘못 설정해서, 목표 이름이 길 때 문제가 있어 다음과 같이 수정했습니다~

|수정전|수정후|  
|:--:|:--:|
![image](https://github.com/user-attachments/assets/933bf47d-a4ca-4b7c-a6f1-58dda8176853) | ![image](https://github.com/user-attachments/assets/8a330cf3-fcc2-48a7-a680-3f95ae57491b) |
