### PR TITLE
QA: 중복 적용된 GoalToggleChip Spacer 삭제

### DIFF
--- a/feature/goal/src/main/kotlin/com/chipichipi/dobedobe/feature/goal/DetailGoalScreen.kt
+++ b/feature/goal/src/main/kotlin/com/chipichipi/dobedobe/feature/goal/DetailGoalScreen.kt
@@ -6,12 +6,10 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -204,7 +202,6 @@ private fun DetailGoalContent(
                 unCheckedIcon = ImageVector.vectorResource(DobeDobeIcons.Unchecked),
                 modifier = Modifier.weight(1f),
             )
-            Spacer(modifier = Modifier.width(16.dp))
             GoalToggleChip(
                 text = stringResource(R.string.feature_detail_goal_pinned_chip),
                 isChecked = goal.isPinned,


### PR DESCRIPTION
DetailGoalScreen 에서 `Arrangement.spacedBy(16.dp)` 와 `Spacer(16.dp)` 를 중복으로 적용했더라구요 ㅎㅎ..   
Spacer를 삭제했습니다!