### PR TITLE
비전보드 포토 변경 시 Cropper 기능 추가

### DIFF
--- a/feature/dashboard/build.gradle.kts
+++ b/feature/dashboard/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
     implementation(libs.accompanist.permission)
     implementation(libs.compose.cloudy)
     implementation(libs.apng)
+    implementation(libs.image.cropper)
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
@@ -16,13 +16,16 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.updateLayoutParams
 import com.canhub.cropper.CropImageView
+import com.chipichipi.dobedobe.core.designsystem.component.ThemePreviews
 import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
 
 @Composable
@@ -107,6 +110,27 @@ private fun ActionTextButton(
             text = text,
             style = DobeDobeTheme.typography.body1,
             color = DobeDobeTheme.colors.white,
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun CropViewScreenPreview() {
+    DobeDobeTheme {
+        val context = LocalContext.current
+        val cropView = remember {
+            CropImageView(context).apply {
+                isAutoZoomEnabled = false
+                cropShape = CropImageView.CropShape.RECTANGLE
+                setFixedAspectRatio(true)
+            }
+        }
+
+        CropViewScreen(
+            onCancel = {},
+            onSave = {},
+            cropImageView = cropView,
         )
     }
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
@@ -21,12 +21,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.updateLayoutParams
 import com.canhub.cropper.CropImageView
 import com.chipichipi.dobedobe.core.designsystem.component.ThemePreviews
 import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
+import com.chipichipi.dobedobe.feature.dashboard.R
 
 @Composable
 internal fun CropViewScreen(
@@ -83,8 +85,14 @@ private fun ActionBar(
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        ActionTextButton(text = "취소", onClick = onCancel)
-        ActionTextButton(text = "저장", onClick = onSave)
+        ActionTextButton(
+            text = stringResource(R.string.feature_dashboard_edit_mode_cancel),
+            onClick = onCancel
+        )
+        ActionTextButton(
+            text = stringResource(R.string.feature_dashboard_edit_mode_confirm),
+            onClick = onSave
+        )
     }
 }
 

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
@@ -1,0 +1,112 @@
+package com.chipichipi.dobedobe.feature.dashboard.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.updateLayoutParams
+import com.canhub.cropper.CropImageView
+import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
+
+@Composable
+internal fun CropViewScreen(
+    onCancel: () -> Unit,
+    onSave: () -> Unit,
+    cropImageView: CropImageView,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(DobeDobeTheme.colors.black)
+            .systemBarsPadding()
+            .padding(bottom = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(30.dp))
+
+        BoxWithConstraints(
+            modifier = Modifier
+                .weight(1f)
+                .padding(horizontal = 20.dp),
+        ) {
+            val (width, height) = with(LocalDensity.current) {
+                maxWidth.roundToPx() to maxHeight.roundToPx()
+            }
+
+            AndroidView(
+                factory = { cropImageView },
+            ) { view ->
+                view.updateLayoutParams {
+                    this.height = height
+                    this.width = width
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(30.dp))
+
+        ActionBar(
+            onCancel = onCancel,
+            onSave = onSave,
+        )
+    }
+}
+
+@Composable
+private fun ActionBar(
+    onCancel: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        ActionTextButton(text = "취소", onClick = onCancel)
+        ActionTextButton(text = "저장", onClick = onSave)
+    }
+}
+
+@Composable
+private fun ActionTextButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val defaultPadding = ButtonDefaults.TextButtonContentPadding
+
+    TextButton(
+        modifier = modifier,
+        onClick = onClick,
+        contentPadding = PaddingValues(
+            start = 24.dp,
+            end = 24.dp,
+            top = defaultPadding.calculateTopPadding(),
+            bottom = defaultPadding.calculateBottomPadding(),
+        ),
+    ) {
+        Text(
+            text = text,
+            style = DobeDobeTheme.typography.body1,
+            color = DobeDobeTheme.colors.white,
+        )
+    }
+}

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/CropViewScreen.kt
@@ -87,11 +87,11 @@ private fun ActionBar(
     ) {
         ActionTextButton(
             text = stringResource(R.string.feature_dashboard_edit_mode_cancel),
-            onClick = onCancel
+            onClick = onCancel,
         )
         ActionTextButton(
             text = stringResource(R.string.feature_dashboard_edit_mode_confirm),
-            onClick = onSave
+            onClick = onSave,
         )
     }
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardEditMode.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardEditMode.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.canhub.cropper.CropImageView
 import com.chipichipi.dobedobe.core.designsystem.component.DobeDobeDialog
 import com.chipichipi.dobedobe.core.designsystem.icon.DobeDobeIcons
 import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
@@ -36,6 +37,8 @@ import com.chipichipi.dobedobe.core.model.DashboardPhoto
 import com.chipichipi.dobedobe.feature.dashboard.R
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardModeState
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoState
+import com.chipichipi.dobedobe.feature.dashboard.util.bitmapToUri
+import com.chipichipi.dobedobe.feature.dashboard.util.deleteDraftFiles
 import com.chipichipi.dobedobe.feature.dashboard.util.updateModifiedPhotosToFile
 import kotlinx.coroutines.launch
 
@@ -49,25 +52,41 @@ internal fun DashboardEditMode(
     modifier: Modifier = Modifier,
 ) {
     var selectedPhotoId by remember { mutableStateOf<Int?>(null) }
+    val context = LocalContext.current
+    var showCropView by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+    val cropView = remember {
+        CropImageView(context).apply {
+            isAutoZoomEnabled = false
+            cropShape = CropImageView.CropShape.RECTANGLE
+            setFixedAspectRatio(true)
+        }
+    }
 
     val photoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
         onResult = { uri ->
             if (selectedPhotoId != null && uri != null) {
-                onUpdatePhotoDrafts(selectedPhotoId, uri)
+                cropView.setImageUriAsync(uri)
+                showCropView = true
             }
-
-            selectedPhotoId = null
         },
     )
 
+    val onExitEditMode: () -> Unit = {
+        coroutineScope.launch {
+            deleteDraftFiles(context)
+            onToggleMode()
+        }
+    }
+
     BackHandler {
-        onToggleMode()
+        onExitEditMode()
     }
 
     DashboardEditModeBody(
         modifier = modifier,
-        onToggleMode = onToggleMode,
+        onToggleMode = onExitEditMode,
         photoDraftsState = modeState.drafts,
         onUpsertPhotos = onUpsertPhotos,
         onDeletePhotos = onDeletePhotos,
@@ -86,6 +105,28 @@ internal fun DashboardEditMode(
             selectedPhotoId = id
         },
     )
+
+    if (showCropView) {
+        CropViewScreen(
+            onCancel = {
+                showCropView = false
+                selectedPhotoId = null
+            },
+            onSave = {
+                coroutineScope.launch {
+                    cropView.getCroppedImage()?.let { croppedImage ->
+                        val uri = bitmapToUri(context, croppedImage)
+                        if (uri != null && selectedPhotoId != null) {
+                            onUpdatePhotoDrafts(selectedPhotoId, uri)
+                            showCropView = false
+                            selectedPhotoId = null
+                        }
+                    }
+                }
+            },
+            cropImageView = cropView,
+        )
+    }
 }
 
 @Composable

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardEditMode.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardEditMode.kt
@@ -55,7 +55,7 @@ internal fun DashboardEditMode(
     val context = LocalContext.current
     var showCropView by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
-    val cropView = remember {
+    val cropView = remember(context) {
         CropImageView(context).apply {
             isAutoZoomEnabled = false
             cropShape = CropImageView.CropShape.RECTANGLE

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardTopAppBar.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardTopAppBar.kt
@@ -87,7 +87,7 @@ internal fun DashboardEditModeTopAppBar(
                     Text(
                         modifier = Modifier
                             .clickable(onClick = onToggleMode),
-                        text = stringResource(R.string.feature_dashboard_edit_mode_top_bar_cancel),
+                        text = stringResource(R.string.feature_dashboard_edit_mode_cancel),
                         style = DobeDobeTheme.typography.body1,
                         color = DobeDobeTheme.colors.white,
                     )
@@ -98,7 +98,7 @@ internal fun DashboardEditModeTopAppBar(
                     contentPadding = PaddingValues(horizontal = 24.dp),
                 ) {
                     Text(
-                        text = stringResource(R.string.feature_dashboard_edit_mode_top_bar_confirm),
+                        text = stringResource(R.string.feature_dashboard_edit_mode_confirm),
                         style = DobeDobeTheme.typography.body1,
                         color = DobeDobeTheme.colors.green2,
                     )

--- a/feature/dashboard/src/main/res/values-en/strings.xml
+++ b/feature/dashboard/src/main/res/values-en/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_dashboard">Home</string>
-    <string name="feature_dashboard_edit_mode_top_bar_confirm">Save</string>
-    <string name="feature_dashboard_edit_mode_top_bar_cancel">Cancel</string>
+    <string name="feature_dashboard_edit_mode_confirm">Save</string>
+    <string name="feature_dashboard_edit_mode_cancel">Cancel</string>
     <string name="feature_dashboard_edit_mode_description">Please select the photo you want to change.</string>
     <string name="feature_dashboard_goal_notification_prompt">Notification permission is needed to remind\n you of your goals outside the app.</string>
     <string name="feature_dashboard_goal_notification_description">please allow Notification permission</string>

--- a/feature/dashboard/src/main/res/values/strings.xml
+++ b/feature/dashboard/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="feature_dashboard">홈</string>
-    <string name="feature_dashboard_edit_mode_top_bar_confirm">저장</string>
-    <string name="feature_dashboard_edit_mode_top_bar_cancel">취소</string>
+    <string name="feature_dashboard_edit_mode_confirm">저장</string>
+    <string name="feature_dashboard_edit_mode_cancel">취소</string>
     <string name="feature_dashboard_edit_mode_description">변경하고 싶은 사진을 선택해 주세요</string>
     <string name="feature_dashboard_goal_notification_prompt">앱 밖에서도 목표를\n되새길 수 있어요</string>
     <string name="feature_dashboard_goal_notification_description">알림 권한이 필요해요</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ permission = "0.37.0"
 apng = "3.0.1"
 coil = "3.0.4"
 cloudy = "0.2.4"
+imageCropper = "4.6.0"
 moduleGraph = "2.7.1"
 koin = "4.0.1"
 ktlint = "12.1.0"
@@ -109,6 +110,7 @@ coil-kt = { group = "io.coil-kt.coil3", name = "coil", version.ref = "coil" }
 coil-kt-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-kt-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 compose-cloudy = { module = "com.github.skydoves:cloudy", version.ref = "cloudy" }
+image-cropper = { module = "com.vanniktech:android-image-cropper", version.ref = "imageCropper" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
대시보드 비전보드에서 포토 선택 및 수정 시 Cropper가 기본적으로 제공되도록 하는 기능 추가입니다.
- https://github.com/CanHub/Android-Image-Cropper 라이브러리 사용 
  -  Photo Crop 시 디자인 시안처럼 하단에 '취소'----'저장' 로우를 나타낼 수 있게 ActionBar 컴포저블을 직접 구현하고 액션만 연결해주면 되기에 해당 라이브러리 선택
<img width="311" alt="image" src="https://github.com/user-attachments/assets/9e864e54-a90e-428d-9df7-c5471c168928" />

  - 해당 라이브러리는 bitmap을 반환함. 그러나, 기존 비전보드 구조는 uri를 저장하는 구조이기에, 최대한 기존 구조를 유지하여 가져갈 수 있도록 bitmap을 uri로 변환하여 저장하는 과정으로 로직 변경
  - Draft 상황에서는 uri이 아니라 bitmap을 들고 있어야 하기에 "draft_"를 prefix로 네이밍하여 cacheDir에 임시 저장해두고, 
    - EditMode에서 벗어나는 경우, draft prefix로 된 cacheDir내 파일을 제거할 수 있도록 구성
    - Save하는 경우, draft를 filesDir에 저장하고, draft prefix로 된 cacheDir내 파일은 제거

