### PR TITLE
Setting QT 반영

### DIFF
--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingScreen.kt
@@ -1,8 +1,11 @@
 package com.chipichipi.dobedobe.feature.setting
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -10,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -35,11 +39,11 @@ internal fun SettingRoute(
     modifier: Modifier = Modifier,
     viewModel: SettingViewModel = koinViewModel(),
 ) {
-    val isGoalNotificationEnabled by viewModel.isGoalNotificationEnabled.collectAsStateWithLifecycle()
+    val settingUiState by viewModel.settingUiState.collectAsStateWithLifecycle()
 
     SettingScreen(
         modifier = modifier,
-        isGoalNotificationEnabled = isGoalNotificationEnabled,
+        uiState = settingUiState,
         navigateToBack = navigateToBack,
         onNotificationToggled = viewModel::setGoalNotificationEnabled,
     )
@@ -47,12 +51,11 @@ internal fun SettingRoute(
 
 @Composable
 private fun SettingScreen(
-    isGoalNotificationEnabled: Boolean,
+    uiState: SettingUiState,
     navigateToBack: () -> Unit,
     onNotificationToggled: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -62,13 +65,26 @@ private fun SettingScreen(
         },
         containerColor = DobeDobeTheme.colors.gray50,
     ) { innerPadding ->
-        SettingBody(
-            isGoalNotificationEnabled = isGoalNotificationEnabled,
-            onNotificationToggled = onNotificationToggled,
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
-        )
+            contentAlignment = Alignment.Center,
+        ) {
+            when (uiState) {
+                is SettingUiState.Loading -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+                is SettingUiState.Success -> {
+                    SettingBody(
+                        isGoalNotificationEnabled = uiState.isGoalNotificationEnabled,
+                        onNotificationToggled = onNotificationToggled,
+                    )
+                }
+            }
+        }
     }
 
     GoalNotificationEffect(
@@ -93,13 +109,14 @@ private fun SettingBody(
     }
 
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize(),
     ) {
         SettingRow(
             label = stringResource(R.string.feature_setting_goal_notifications),
             onClick = {
                 handleNotificationToggle(!isGoalNotificationEnabled)
-            }
+            },
         ) {
             DobeDobeSwitch(
                 modifier = Modifier.padding(end = 8.dp),
@@ -112,7 +129,7 @@ private fun SettingBody(
 
         SettingRow(
             label = stringResource(R.string.feature_setting_app_feedback),
-            onClick = { openPlayStore(context) }
+            onClick = { openPlayStore(context) },
         ) {
             Icon(
                 painter = painterResource(DobeDobeIcons.ArrowForward),

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingScreen.kt
@@ -3,9 +3,7 @@ package com.chipichipi.dobedobe.feature.setting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,6 +52,7 @@ private fun SettingScreen(
     onNotificationToggled: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -85,38 +84,41 @@ private fun SettingBody(
 ) {
     val context = LocalContext.current
 
+    val handleNotificationToggle: (Boolean) -> Unit = { enabled ->
+        NotificationUtil.handleNotificationToggle(
+            context = context,
+            enabled = enabled,
+            onNotificationToggled = onNotificationToggled,
+        )
+    }
+
     Column(
         modifier = modifier,
     ) {
         SettingRow(
             label = stringResource(R.string.feature_setting_goal_notifications),
+            onClick = {
+                handleNotificationToggle(!isGoalNotificationEnabled)
+            }
         ) {
             DobeDobeSwitch(
                 modifier = Modifier.padding(end = 8.dp),
                 checked = isGoalNotificationEnabled,
                 onCheckedChange = { checked ->
-                    NotificationUtil.handleNotificationToggle(
-                        context = context,
-                        enabled = checked,
-                        onNotificationToggled = onNotificationToggled,
-                    )
+                    handleNotificationToggle(checked)
                 },
             )
         }
 
         SettingRow(
             label = stringResource(R.string.feature_setting_app_feedback),
+            onClick = { openPlayStore(context) }
         ) {
-            IconButton(
-                modifier = Modifier.size(42.dp),
-                onClick = { openPlayStore(context) },
-            ) {
-                Icon(
-                    painter = painterResource(DobeDobeIcons.ArrowForward),
-                    contentDescription = null,
-                    tint = Color.Unspecified,
-                )
-            }
+            Icon(
+                painter = painterResource(DobeDobeIcons.ArrowForward),
+                contentDescription = null,
+                tint = Color.Unspecified,
+            )
         }
     }
 }

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingUiState.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingUiState.kt
@@ -1,0 +1,9 @@
+package com.chipichipi.dobedobe.feature.setting
+
+sealed interface SettingUiState {
+    data object Loading : SettingUiState
+
+    data class Success(
+        val isGoalNotificationEnabled: Boolean,
+    ) : SettingUiState
+}

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/SettingViewModel.kt
@@ -11,12 +11,12 @@ import kotlinx.coroutines.launch
 internal class SettingViewModel(
     private val userRepository: UserRepository,
 ) : ViewModel() {
-    val isGoalNotificationEnabled = userRepository.userData
-        .map { it.isGoalNotificationEnabled }
+    val settingUiState = userRepository.userData
+        .map { SettingUiState.Success(it.isGoalNotificationEnabled) }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = false,
+            initialValue = SettingUiState.Loading,
         )
 
     fun setGoalNotificationEnabled(checked: Boolean) {

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/component/SettingRow.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/component/SettingRow.kt
@@ -1,5 +1,7 @@
 package com.chipichipi.dobedobe.feature.setting.component
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,7 +10,9 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -18,6 +22,7 @@ import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
 @Composable
 internal fun SettingRow(
     label: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
     trailingContent: @Composable () -> Unit,
 ) {
@@ -29,6 +34,11 @@ internal fun SettingRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(52.dp)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = ripple(),
+                    onClick = onClick,
+                )
                 .padding(
                     start = 24.dp,
                     end = 8.dp,
@@ -59,6 +69,7 @@ private fun SettingRowPreview() {
     DobeDobeTheme {
         SettingRow(
             label = "TEST",
+            onClick = {},
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/component/SettingRow.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/component/SettingRow.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.chipichipi.dobedobe.core.designsystem.component.ThemePreviews
 import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
@@ -37,6 +38,7 @@ internal fun SettingRow(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = ripple(),
+                    role = Role.Button,
                     onClick = onClick,
                 )
                 .padding(

--- a/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/util/SettingUtil.kt
+++ b/feature/setting/src/main/kotlin/com/chipichipi/dobedobe/feature/setting/util/SettingUtil.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 
-// TODO : 주소 확인 필요
 internal fun openPlayStore(context: Context) {
     val intent = Intent(
         Intent.ACTION_VIEW,


### PR DESCRIPTION
- 셋팅 로우 자체로 클릭 영역 확장
- SettingUiState로 구조를 변경함으로써 isGoalNotificationEnabled StateFlow의 initialValue와 로컬에 저장된 값이 다를 때 생기는 딜레이 제거

cc @easyhooon 