### PR TITLE
대시보드에서 검색화면 이동할 때 BottomSheet PartiallyExpand 처리 

### DIFF
--- a/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
+++ b/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -18,6 +19,7 @@ import kotlinx.coroutines.launch
 import org.koin.androidx.compose.KoinAndroidContext
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
     private val viewModel: MainViewModel by viewModel()
 

--- a/app/src/main/kotlin/com/chipichipi/dobedobe/navigation/DobeDobeNavHost.kt
+++ b/app/src/main/kotlin/com/chipichipi/dobedobe/navigation/DobeDobeNavHost.kt
@@ -2,6 +2,7 @@ package com.chipichipi.dobedobe.navigation
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,6 +26,7 @@ import com.chipichipi.dobedobe.feature.setting.navigation.navigateToSetting
 import com.chipichipi.dobedobe.feature.setting.navigation.settingScreen
 import com.chipichipi.dobedobe.ui.DobeDobeAppState
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DobeDobeNavHost(
     appState: DobeDobeAppState,
@@ -33,6 +35,7 @@ internal fun DobeDobeNavHost(
 ) {
     val navController = appState.navController
     val backStackEntry by navController.currentBackStackEntryAsState()
+    val bottomSheetScaffoldState = appState.bottomSheetScaffoldState
 
     NavHost(
         navController = navController,
@@ -43,10 +46,14 @@ internal fun DobeDobeNavHost(
     ) {
         dashboardScreen(
             onShowSnackbar = onShowSnackbar,
+            bottomSheetScaffoldState = bottomSheetScaffoldState,
             navigateToAddGoal = navController::navigateToAddGoal,
             navigateToGoalDetail = navController::navigateToGoalDetail,
             navigateToSetting = navController::navigateToSetting,
-            navigateToSearchGoal = navController::navigateToSearchGoal,
+            navigateToSearchGoal = {
+                navController.navigateToSearchGoal()
+                appState.partiallyExpand()
+            },
         )
 
         goalGraph(

--- a/app/src/main/kotlin/com/chipichipi/dobedobe/ui/DobeDobeAppState.kt
+++ b/app/src/main/kotlin/com/chipichipi/dobedobe/ui/DobeDobeAppState.kt
@@ -1,5 +1,10 @@
 package com.chipichipi.dobedobe.ui
 
+import androidx.compose.material3.BottomSheetScaffoldState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetScaffoldState
+import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -9,10 +14,17 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun rememberDobeDobeAppState(
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    bottomSheetScaffoldState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded,
+        ),
+    ),
     navController: NavHostController = rememberNavController(),
 ): DobeDobeAppState {
     return remember(
@@ -21,19 +33,28 @@ internal fun rememberDobeDobeAppState(
     ) {
         DobeDobeAppState(
             coroutineScope = coroutineScope,
+            bottomSheetScaffoldState = bottomSheetScaffoldState,
             navController = navController,
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Stable
 class DobeDobeAppState(
-    coroutineScope: CoroutineScope,
+    val coroutineScope: CoroutineScope,
+    val bottomSheetScaffoldState: BottomSheetScaffoldState,
     val navController: NavHostController,
 ) {
     fun navigateToBack(from: NavBackStackEntry) {
         if (from.lifecycleIsResumed()) {
             navController.popBackStack()
+        }
+    }
+
+    fun partiallyExpand() {
+        coroutineScope.launch {
+            bottomSheetScaffoldState.bottomSheetState.partialExpand()
         }
     }
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
@@ -13,12 +13,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SheetValue
-import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -57,9 +56,11 @@ import org.koin.androidx.compose.koinViewModel
 
 private const val ANIMATION_DURATION = 500
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun DashboardRoute(
     onShowSnackbar: suspend (String, String?) -> Boolean,
+    bottomSheetScaffoldState: BottomSheetScaffoldState,
     navigateToAddGoal: () -> Unit,
     navigateToGoalDetail: (Long) -> Unit,
     navigateToSetting: () -> Unit,
@@ -74,6 +75,7 @@ internal fun DashboardRoute(
         modifier = modifier.fillMaxSize(),
         onShowSnackbar = onShowSnackbar,
         uiState = uiState,
+        bottomSheetScaffoldState = bottomSheetScaffoldState,
         setGoalNotificationEnabled = viewModel::setGoalNotificationEnabled,
         disableSystemNotificationDialog = viewModel::disableSystemNotificationDialog,
         navigateToAddGoal = navigateToAddGoal,
@@ -90,10 +92,12 @@ internal fun DashboardRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DashboardScreen(
     onShowSnackbar: suspend (String, String?) -> Boolean,
     uiState: DashboardUiState,
+    bottomSheetScaffoldState: BottomSheetScaffoldState,
     setGoalNotificationEnabled: (Boolean) -> Unit,
     disableSystemNotificationDialog: () -> Unit,
     navigateToAddGoal: () -> Unit,
@@ -126,6 +130,7 @@ private fun DashboardScreen(
                 DashboardBody(
                     modifier = modifier,
                     uiState = uiState,
+                    bottomSheetScaffoldState = bottomSheetScaffoldState,
                     setGoalNotificationEnabled = setGoalNotificationEnabled,
                     disableSystemNotificationDialog = disableSystemNotificationDialog,
                     navigateToAddGoal = navigateToAddGoal,
@@ -150,6 +155,7 @@ private fun DashboardScreen(
 @Composable
 private fun DashboardBody(
     uiState: DashboardUiState.Success,
+    bottomSheetScaffoldState: BottomSheetScaffoldState,
     setGoalNotificationEnabled: (Boolean) -> Unit,
     disableSystemNotificationDialog: () -> Unit,
     navigateToAddGoal: () -> Unit,
@@ -170,11 +176,6 @@ private fun DashboardBody(
     SharedTransitionLayout(
         modifier = modifier,
     ) {
-        val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(
-            bottomSheetState = rememberStandardBottomSheetState(
-                initialValue = SheetValue.PartiallyExpanded,
-            ),
-        )
         val photoFramesState = rememberDashboardPhotoFramesState(
             photoState = uiState.photoState,
         )
@@ -186,6 +187,7 @@ private fun DashboardBody(
             }
         }
         val resources = CharacterResources.from(uiState.character)
+
         DobeDobeBottomSheetScaffold(
             modifier = Modifier
                 .fillMaxSize()

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/navigation/DashboardNavigation.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/navigation/DashboardNavigation.kt
@@ -1,5 +1,7 @@
 package com.chipichipi.dobedobe.feature.dashboard.navigation
 
+import androidx.compose.material3.BottomSheetScaffoldState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -14,8 +16,10 @@ fun NavController.navigateToDashboard(
     navOptions: NavOptions,
 ) = navigate(route = DashboardRoute, navOptions)
 
+@OptIn(ExperimentalMaterial3Api::class)
 fun NavGraphBuilder.dashboardScreen(
     onShowSnackbar: suspend (String, String?) -> Boolean,
+    bottomSheetScaffoldState: BottomSheetScaffoldState,
     navigateToAddGoal: () -> Unit,
     navigateToGoalDetail: (Long) -> Unit,
     navigateToSearchGoal: () -> Unit,
@@ -24,6 +28,7 @@ fun NavGraphBuilder.dashboardScreen(
     composable<DashboardRoute> {
         DashboardRoute(
             onShowSnackbar = onShowSnackbar,
+            bottomSheetScaffoldState = bottomSheetScaffoldState,
             navigateToAddGoal = navigateToAddGoal,
             navigateToGoalDetail = navigateToGoalDetail,
             navigateToSetting = navigateToSetting,


### PR DESCRIPTION
준혁님 말씀대로 AppState 에 DashBoard의 바텀시트의 상태를 가지고 있다는게 조금 어색하지만..  
딱히 방법을 찾지 못했습니다 😂  

 검색화면으로 이동 할 경우, DashBoardScreen 의 BottomSheetScaffoldState 가 비활성화되어 PartiallyExpand 이 적용되지 않았습니다.  
제시해주신 방안대로,  BottomSheetScaffoldState를 App 단까지 호이스팅해서 처리했습니다~  
한 수 또 배워갑니다 준혁님 ㅎㅎ