### PR TITLE
말풍선 디테일 잡기

### DIFF
--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
@@ -126,7 +126,6 @@ private fun DashboardScreen(
                     navigateToSetting = navigateToSetting,
                     navigateToSearchGoal = navigateToSearchGoal,
                     onGoalToggled = onGoalToggled,
-                    // TODO: 캐릭터 누르면 말풍선 바뀌는걸로 옮기기!
                     onChangeBubble = onChangeBubble,
                     onToggleMode = onToggleMode,
                     onUpsertPhotos = onUpsertPhotos,
@@ -217,11 +216,12 @@ private fun DashboardBody(
                 DashboardViewMode(
                     isViewMode = !isEditMode,
                     photoState = uiState.photoState,
-                    bubbleTitle = uiState.bubbleTitle,
+                    bubbleGoal = uiState.bubbleGoal,
                     photoFramesState = photoFramesState,
                     onChangeBubble = onChangeBubble,
                     onToggleExpansion = onToggleExpansion,
                     onToggleMode = onToggleMode,
+                    navigateToGoalDetail = navigateToGoalDetail,
                     navigateToSetting = navigateToSetting,
                     character = uiState.character,
                 )

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardUiState.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardUiState.kt
@@ -2,6 +2,7 @@ package com.chipichipi.dobedobe.feature.dashboard
 
 import com.chipichipi.dobedobe.core.model.CharacterType
 import com.chipichipi.dobedobe.core.model.Goal
+import com.chipichipi.dobedobe.feature.dashboard.model.BubbleGoal
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoState
 
 sealed interface DashboardUiState {
@@ -11,7 +12,7 @@ sealed interface DashboardUiState {
         val photoState: List<DashboardPhotoState>,
         val isSystemNotificationDialogDisabled: Boolean,
         val goals: List<Goal>,
-        val bubbleTitle: String,
+        val bubbleGoal: BubbleGoal,
         val character: CharacterType,
     ) : DashboardUiState
 

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
@@ -9,6 +9,7 @@ import com.chipichipi.dobedobe.core.data.repository.GoalRepository
 import com.chipichipi.dobedobe.core.data.repository.UserRepository
 import com.chipichipi.dobedobe.core.model.DashboardPhoto
 import com.chipichipi.dobedobe.core.model.Goal
+import com.chipichipi.dobedobe.feature.dashboard.model.BubbleGoal
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardModeState
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoConfig
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoState
@@ -74,7 +75,7 @@ internal class DashboardViewModel(
             photoState = dashboardPhotoStates,
             isSystemNotificationDialogDisabled = isSystemNotificationDialogDisabled,
             goals = goals,
-            bubbleTitle = bubbleGoal.title,
+            bubbleGoal = bubbleGoal,
             character = character,
         )
     }
@@ -236,21 +237,6 @@ internal class DashboardViewModel(
         } else {
             val newGoal = candidates.random()
             BubbleGoal.from(newGoal) to goals
-        }
-    }
-
-    private data class BubbleGoal(
-        val title: String,
-        val id: Long?,
-    ) {
-        companion object {
-            private val Empty = BubbleGoal(title = "", id = null)
-
-            fun empty(): BubbleGoal = Empty
-
-            fun from(goal: Goal): BubbleGoal {
-                return BubbleGoal(goal.title, goal.id)
-            }
         }
     }
 

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
@@ -205,12 +205,10 @@ internal class DashboardViewModel(
         val containsCurrentBubble = goals.any { it.id == currentBubble.id }
 
         if (containsCurrentBubble) {
-            // 현재 버블이 여전히 목록에 있으면 그대로 유지
             return currentBubble to goals
         }
 
         if (goals.isEmpty()) {
-            // 목록이 비었으면 empty 상태로 반환
             return BubbleGoal.empty() to goals
         }
 

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardViewModel.kt
@@ -21,8 +21,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -163,44 +164,79 @@ internal class DashboardViewModel(
         }
     }
 
-    /**
-     * bubbleGoal 을 random 으로 변경하는 로직
-     *
-     * - todoGoals 가 empty 일 경우, Empty BubbleGoal 을 반환
-     * - todoGoals 가 empty 가 아닌 경우
-     *
-     * 1) goalRepository 에 있는 goal 이 변경될 경우
-     *      1-1) old goals 와 new goals 가 다르면 변경
-     *      1-2) 만약, bubbleGoal 의 id 가 todoGoals 에 포함되어 있으면 변경
-     *
-     * 2) changeBubbleEvent 가 발생할 경우
-     *      - 무조건 random 하게 변경
-     * */
     private fun bubbleGoalFlow(): Flow<BubbleGoal> {
-        val todoGoals: Flow<List<Goal>> = goalRepository.getTodoGoals()
-            .distinctUntilChanged()
-            .distinctUntilChanged { _, new ->
-                val id = bubbleGoal.value.id
-                val isBubbleGoalCompleted = new.any { it.id == id }
-                isBubbleGoalCompleted
-            }
+        val events: Flow<BubbleGoalEvent> = merge(
+            goalRepository.getTodoGoals().map { goals -> BubbleGoalEvent.GoalsChanged(goals) },
+            changeBubbleEvent.receiveAsFlow().map { BubbleGoalEvent.BubbleChanged },
+        )
 
-        return combine(
-            todoGoals,
-            changeBubbleEvent.receiveAsFlow().onStart {
-                emit(Unit)
-            },
-        ) { goals, _ ->
-            goals.filter { it.id != bubbleGoal.value.id }.shuffled()
-        }
-            .map(List<Goal>::firstOrNull)
-            .map { goal ->
-                if (goal != null) {
-                    BubbleGoal.from(goal)
-                } else {
-                    BubbleGoal.empty()
+        return events
+            .runningFold(BubbleGoal.empty() to emptyList<Goal>()) { acc, event ->
+                val (currentBubble, latestGoals) = acc
+
+                when (event) {
+                    is BubbleGoalEvent.GoalsChanged -> handleGoalsChangedEvent(
+                        event.goals,
+                        currentBubble,
+                    )
+
+                    is BubbleGoalEvent.BubbleChanged -> handleBubbleChangedEvent(
+                        latestGoals,
+                        currentBubble,
+                    )
                 }
             }
+            .map { it.first }
+    }
+
+    /**
+     * goals 이 변경될 때(e. toggle, delete) BubbleGoal 을 업데이트하는 함수.
+     *
+     * 1) BubbleGoal 이 goals 에 포함되어 있으면 그대로 유지
+     * 2) BubbleGoal 이 goals 에 포함 x
+     *    - goals 이 비어있으면 empty 상태로 반환
+     *    - goals 이 존재하면 랜덤으로 선택하여 새로운 BubbleGoal 을 생성
+     * */
+    private fun handleGoalsChangedEvent(
+        goals: List<Goal>,
+        currentBubble: BubbleGoal,
+    ): Pair<BubbleGoal, List<Goal>> {
+        val containsCurrentBubble = goals.any { it.id == currentBubble.id }
+
+        if (containsCurrentBubble) {
+            // 현재 버블이 여전히 목록에 있으면 그대로 유지
+            return currentBubble to goals
+        }
+
+        if (goals.isEmpty()) {
+            // 목록이 비었으면 empty 상태로 반환
+            return BubbleGoal.empty() to goals
+        }
+
+        val newGoal = goals.random()
+        return BubbleGoal.from(newGoal) to goals
+    }
+
+    /**
+     * 버블 변경 이벤트(BubbleChanged)가 발생했을 때 현재 BubbleGoal 을 업데이트하는 함수.
+     *
+     * candidates: 현재 BubbleGoal 을 제외한 후보 목록
+     *
+     * 1) 후보 목록이 비어있으면 현재 BubbleGoal 을 그대로 반환
+     * 2) 후보 목록이 존재하면 후보 목록 중 랜덤으로 선택하여 새로운 BubbleGoal 을 생성
+     * */
+    private fun handleBubbleChangedEvent(
+        goals: List<Goal>,
+        currentBubble: BubbleGoal,
+    ): Pair<BubbleGoal, List<Goal>> {
+        val candidates = goals.filter { it.id != currentBubble.id }
+
+        return if (candidates.isEmpty()) {
+            currentBubble to goals
+        } else {
+            val newGoal = candidates.random()
+            BubbleGoal.from(newGoal) to goals
+        }
     }
 
     private data class BubbleGoal(
@@ -216,5 +252,11 @@ internal class DashboardViewModel(
                 return BubbleGoal(goal.title, goal.id)
             }
         }
+    }
+
+    private sealed class BubbleGoalEvent {
+        data class GoalsChanged(val goals: List<Goal>) : BubbleGoalEvent()
+
+        data object BubbleChanged : BubbleGoalEvent()
     }
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardCharacter.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardCharacter.kt
@@ -31,6 +31,7 @@ internal fun DashboardCharacter(
     @RawRes defaultApngRes: Int,
     @RawRes reactionApngRes: Int,
     @DrawableRes placeholder: Int,
+    onChangeBubble: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -45,6 +46,7 @@ internal fun DashboardCharacter(
 
     LaunchedEffect(isResetTrigger) {
         if (isResetTrigger) {
+            onChangeBubble()
             delay(4000)
             currentRaw = defaultApngRes
             isResetTrigger = false
@@ -81,6 +83,7 @@ private fun DashboardCharacterPreview() {
             defaultApngRes = R.raw.rabbit01,
             reactionApngRes = R.raw.rabbit02,
             placeholder = R.drawable.rabbit_placeholder,
+            onChangeBubble = {},
         )
     }
 }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardViewMode.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/component/DashboardViewMode.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.zIndex
 import com.chipichipi.dobedobe.core.designsystem.theme.DobeDobeTheme
 import com.chipichipi.dobedobe.core.model.CharacterType
 import com.chipichipi.dobedobe.feature.dashboard.DashboardPhotoFramesState
+import com.chipichipi.dobedobe.feature.dashboard.model.BubbleGoal
 import com.chipichipi.dobedobe.feature.dashboard.model.CharacterResources
 import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoState
 
@@ -27,12 +28,13 @@ import com.chipichipi.dobedobe.feature.dashboard.model.DashboardPhotoState
 internal fun SharedTransitionScope.DashboardViewMode(
     isViewMode: Boolean,
     photoState: List<DashboardPhotoState>,
-    bubbleTitle: String,
+    bubbleGoal: BubbleGoal,
     photoFramesState: DashboardPhotoFramesState,
     onChangeBubble: () -> Unit,
     onToggleExpansion: (Int) -> Unit,
     onToggleMode: () -> Unit,
     navigateToSetting: () -> Unit,
+    navigateToGoalDetail: (Long) -> Unit,
     character: CharacterType,
     modifier: Modifier = Modifier,
 ) {
@@ -76,13 +78,17 @@ internal fun SharedTransitionScope.DashboardViewMode(
                 ) {
                     Spacer(Modifier.height(14.dp))
                     DashboardBubble(
-                        title = bubbleTitle,
+                        title = bubbleGoal.title,
                         textStyle = DobeDobeTheme.typography.body2,
                         modifier = Modifier
                             .background(
                                 color = DobeDobeTheme.colors.white,
                             ),
-                        onClick = onChangeBubble,
+                        onClick = {
+                            if (bubbleGoal.id != null) {
+                                navigateToGoalDetail(bubbleGoal.id)
+                            }
+                        },
                     )
                     DashboardCharacter(
                         modifier = Modifier
@@ -91,6 +97,7 @@ internal fun SharedTransitionScope.DashboardViewMode(
                         defaultApngRes = resources.defaultApngRes,
                         reactionApngRes = resources.reactionApngRes,
                         placeholder = resources.placeholderRes,
+                        onChangeBubble = onChangeBubble,
                     )
                 }
             }

--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/model/BubbleGoal.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/model/BubbleGoal.kt
@@ -1,0 +1,18 @@
+package com.chipichipi.dobedobe.feature.dashboard.model
+
+import com.chipichipi.dobedobe.core.model.Goal
+
+data class BubbleGoal(
+    val title: String,
+    val id: Long?,
+) {
+    companion object {
+        private val Empty = BubbleGoal(title = "", id = null)
+
+        fun empty(): BubbleGoal = Empty
+
+        fun from(goal: Goal): BubbleGoal {
+            return BubbleGoal(goal.title, goal.id)
+        }
+    }
+}


### PR DESCRIPTION
- closed #66   



- 기존 말풍선 변경 로직이 조금 문제가 있어서 변경했습니다~  말풍선이 바뀌는 케이스는 크게 아래 2가지입니다~ 이에 따라 분기처리해봤습니다. 
    1) Goal 리스트가 바뀌는 경우 (목표 삭제, 목표 토글 등등..)
    2) (구) 말풍선 클릭, (신) 캐릭터 클릭 시

- 캐릭터 click 시 말풍선이 변경되도록 수정했습니다. 
- 말풍선 click 시 디테일 화면으로 넘어가도록 수정했습니다.
   - 이 과정에서 BubbleGoal 을 feature model 로 옮겼습니다.