### PR TITLE
Status Bar 라이트 모드로 강제화

### DIFF
--- a/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
+++ b/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -27,6 +28,10 @@ class MainActivity : ComponentActivity() {
         ActivityInfo.SCREEN_ORIENTATION_PORTRAIT.also { requestedOrientation = it }
 
         enableEdgeToEdge()
+        WindowInsetsControllerCompat(window, window.decorView).apply {
+            // enforce light status bar
+            isAppearanceLightStatusBars = true
+        }
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
+++ b/app/src/main/kotlin/com/chipichipi/dobedobe/MainActivity.kt
@@ -3,10 +3,12 @@ package com.chipichipi.dobedobe
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -27,11 +29,12 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         ActivityInfo.SCREEN_ORIENTATION_PORTRAIT.also { requestedOrientation = it }
 
-        enableEdgeToEdge()
-        WindowInsetsControllerCompat(window, window.decorView).apply {
-            // enforce light status bar
-            isAppearanceLightStatusBars = true
-        }
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(
+                Color.Transparent.toArgb(),
+                Color.Transparent.toArgb(),
+            ),
+        )
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {


### PR DESCRIPTION
저희 앱은 현재 다크모드를 지원하고 있지 않고 있어, StatusBar 를 lightMode 로 강제했습니다~

- 기존 다크모드 
![image](https://github.com/user-attachments/assets/278636c2-74b5-40b0-805f-55ba81530255)

- 적용 후
![image](https://github.com/user-attachments/assets/3f1cc3ea-9d1c-4e14-adc6-f6aa983752b8)


enableEdgeToEdge 이 정말 편리한 함수긴 한데, 커스터마이징할 때 배경지식을 상당히 요구하더군요!  
[enableEdgeToEdge 내부 코드 알고 쓰기](https://velog.io/@hyemdooly/enableEdgeToEdge-%EB%82%B4%EB%B6%80-%EC%BD%94%EB%93%9C-%EC%95%8C%EA%B3%A0-%EC%93%B0%EA%B8%B0) 와 내부 코드 참고해서 구현해봤습니다!
