### PR TITLE
Notification Permission을 받기 위한 Dialog를 확실히 받고 다음 행동을 진행할 수 있도록 변경

### DIFF
--- a/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
+++ b/feature/dashboard/src/main/kotlin/com/chipichipi/dobedobe/feature/dashboard/DashboardScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chipichipi.dobedobe.core.designsystem.component.DRAG_HANDLER_HEIGHT
@@ -359,6 +360,11 @@ private fun GoalNotificationPermission(
                 notificationsPermissionState.launchPermissionRequest()
                 showGoalNotificationDialog = false
             },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+            ),
         )
     }
 }


### PR DESCRIPTION
대시보드 진입시 곧바로 Notification Permession을 유도하는데, 이때 다이얼로그 외부 클릭이나 BackPress를 통해 닫게 되면
다시 대시보드로 돌아올 때마다 Dialog를 노출하게 됨.
확실히 받고 넘어갈 수 있도록 Notification Permession Dialog에서는 Properties 변경